### PR TITLE
feat: redesign the layout using divs instead of a table

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -46,7 +46,7 @@ export default function Home() {
         <label htmlFor="search" className="text-2xl font-bold text-zinc-800">Search</label>
         <div>
           <input id="search" onChange={onChange} className="rounded-md p-2 border-2 border-cyan-900 mr-4"/>
-          <button onClick={onClick} className="bg-cyan-500 rounded-md p-2 text-white">Reset Search</button>
+          <button onClick={onClick} className="bg-cyan-500 rounded-md p-2 text-white hover:bg-cyan-700">Reset Search</button>
         </div>
       </div>
       <h2 className="text-2xl font-bold pt-10 pb-5 text-zinc-800">Results</h2>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -62,7 +62,7 @@ export default function Home() {
                   </div>
                   <div>
                     <span className="font-bold mr-2">Phone:</span>
-                    <a href={`tel:${advocate.phoneNumber}`}>{advocate.phoneNumber}</a>
+                    <a href={`tel:${advocate.phoneNumber}`} className="text-cyan-600">{advocate.phoneNumber}</a>
                   </div>
                   <div>
                     <span className="font-bold mr-2">Years Experience:</span>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -19,8 +19,6 @@ export default function Home() {
   const onChange = (e) => {
     const searchTerm = e.target.value;
 
-    document.getElementById("search-term").innerHTML = searchTerm;
-
     console.log("filtering advocates...");
     const filteredAdvocates = advocates.filter((advocate) => {
       return (
@@ -43,44 +41,41 @@ export default function Home() {
 
   return (
     <main style={{ margin: "24px" }}>
-      <h1>Solace Advocates</h1>
-      <br />
-      <br />
-      <div>
-        <p>Search</p>
-        <p>
-          Searching for: <span id="search-term"></span>
-        </p>
-        <input style={{ border: "1px solid black" }} onChange={onChange} />
-        <button onClick={onClick}>Reset Search</button>
+      <h1 className="text-3xl font-bold py-10 text-zinc-800">Solace Advocates</h1>
+      <div className="flex flex-col py-4">
+        <label htmlFor="search" className="text-lg font-bold text-zinc-800">Search</label>
+        <div>
+          <input id="search" onChange={onChange} className="rounded-md p-2 border-2 border-cyan-900 mr-4"/>
+          <button onClick={onClick} className="bg-cyan-500 rounded-md p-2 text-white">Reset Search</button>
+        </div>
       </div>
-      <br />
-      <br />
-      <table>
+      <table className="w-full border-2 border-cyan-900">
         <thead>
-          <th>First Name</th>
-          <th>Last Name</th>
-          <th>City</th>
-          <th>Degree</th>
-          <th>Specialties</th>
-          <th>Years of Experience</th>
-          <th>Phone Number</th>
+          <tr className="bg-cyan-900 text-white">
+            <th className="p-2 text-left">First Name</th>
+            <th className="p-2 text-left">Last Name</th>
+            <th className="p-2 text-left">City</th>
+            <th className="p-2 text-left">Degree</th>
+            <th className="p-2 text-left max-w-lg">Specialties</th>
+            <th className="p-2 text-left">Years of Experience</th>
+            <th className="p-2 text-left">Phone Number</th>
+          </tr>
         </thead>
         <tbody>
           {filteredAdvocates.map((advocate) => {
             return (
-              <tr>
-                <td>{advocate.firstName}</td>
-                <td>{advocate.lastName}</td>
-                <td>{advocate.city}</td>
-                <td>{advocate.degree}</td>
-                <td>
+              <tr className="odd:bg-white even:bg-gray-300 text-sm">
+                <td className="p-2">{advocate.firstName}</td>
+                <td className="p-2">{advocate.lastName}</td>
+                <td className="p-2">{advocate.city}</td>
+                <td className="p-2">{advocate.degree}</td>
+                <td className="p-2 max-w-lg">
                   {advocate.specialties.map((s) => (
-                    <div>{s}</div>
+                    <div className="inline-block px-2 py-1 text-xs font-semibold rounded-full bg-indigo-500 text-white m-1">{s}</div>
                   ))}
                 </td>
-                <td>{advocate.yearsOfExperience}</td>
-                <td>{advocate.phoneNumber}</td>
+                <td className="p-2">{advocate.yearsOfExperience}</td>
+                <td className="p-2">{advocate.phoneNumber}</td>
               </tr>
             );
           })}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -43,44 +43,44 @@ export default function Home() {
     <main style={{ margin: "24px" }}>
       <h1 className="text-3xl font-bold py-10 text-zinc-800">Solace Advocates</h1>
       <div className="flex flex-col py-4">
-        <label htmlFor="search" className="text-lg font-bold text-zinc-800">Search</label>
+        <label htmlFor="search" className="text-2xl font-bold text-zinc-800">Search</label>
         <div>
           <input id="search" onChange={onChange} className="rounded-md p-2 border-2 border-cyan-900 mr-4"/>
           <button onClick={onClick} className="bg-cyan-500 rounded-md p-2 text-white">Reset Search</button>
         </div>
       </div>
-      <table className="w-full border-2 border-cyan-900">
-        <thead>
-          <tr className="bg-cyan-900 text-white">
-            <th className="p-2 text-left">First Name</th>
-            <th className="p-2 text-left">Last Name</th>
-            <th className="p-2 text-left">City</th>
-            <th className="p-2 text-left">Degree</th>
-            <th className="p-2 text-left max-w-lg">Specialties</th>
-            <th className="p-2 text-left">Years of Experience</th>
-            <th className="p-2 text-left">Phone Number</th>
-          </tr>
-        </thead>
-        <tbody>
-          {filteredAdvocates.map((advocate) => {
+      <h2 className="text-2xl font-bold pt-10 pb-5 text-zinc-800">Results</h2>
+      <div className="w-full border-2 border-cyan-900">
+       {filteredAdvocates.map((advocate) => {
             return (
-              <tr className="odd:bg-white even:bg-gray-300 text-sm">
-                <td className="p-2">{advocate.firstName}</td>
-                <td className="p-2">{advocate.lastName}</td>
-                <td className="p-2">{advocate.city}</td>
-                <td className="p-2">{advocate.degree}</td>
-                <td className="p-2 max-w-lg">
-                  {advocate.specialties.map((s) => (
-                    <div className="inline-block px-2 py-1 text-xs font-semibold rounded-full bg-indigo-500 text-white m-1">{s}</div>
-                  ))}
-                </td>
-                <td className="p-2">{advocate.yearsOfExperience}</td>
-                <td className="p-2">{advocate.phoneNumber}</td>
-              </tr>
+              <div className="flex flex-col md:flex-row p-4 odd:bg-white even:bg-gray-200 text-sm" key={advocate.id}>
+                <div className="basis-1/3"> 
+                  <h3 className="text-lg font-bold">{advocate.firstName} {advocate.lastName}, {advocate.degree}</h3>
+                  <div>
+                    <span className="font-bold mr-2">City:</span>
+                    <span>{advocate.city}</span>
+                  </div>
+                  <div>
+                    <span className="font-bold mr-2">Phone:</span>
+                    <a href={`tel:${advocate.phoneNumber}`}>{advocate.phoneNumber}</a>
+                  </div>
+                  <div>
+                    <span className="font-bold mr-2">Years Experience:</span>
+                    <span>{advocate.yearsOfExperience}</span>
+                  </div>
+                </div>
+                <div className="basis-2/3">
+                  <h4 className="font-bold mb-2">Specialties</h4>
+                  <div>
+                    {advocate.specialties.map((s) => (
+                      <div className="inline-block px-2 py-1 text-xs font-semibold rounded-full bg-indigo-500 text-white m-1">{s}</div>
+                    ))}
+                  </div>
+                </div>
+              </div>
             );
           })}
-        </tbody>
-      </table>
+      </div>
     </main>
   );
 }


### PR DESCRIPTION
## Why
The original page didn't have any styles applied, and while the default browser table styles were at least making the data organized it was not easy to read and digest for a user. Additionally since tables are more structured it limits the design especially if we want to add more information to our advocate object.


## What
This PR replaces the table with a layout using divs along with other style updates to make things easier for the user.
Specific updates
- Add text styles to introduce some text hierarchy
- button styles to make them stand out as interactable
- Divide up the advocate layout into basic info and specialties
  - Combine `firstName`, `lastName`, and `degree` fields to make the name more easily readable
  - style the specialties as pills