### PR TITLE
feat: add pagination and database searching

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-#DATABASE_URL=postgresql://postgres:password@localhost/solaceassignment
+DATABASE_URL=postgresql://postgres:password@localhost/solaceassignment

--- a/DISCUSSION.md
+++ b/DISCUSSION.md
@@ -1,5 +1,13 @@
-## TODO
+## Things I would have liked to do with more time
 
+Here are just a few things that I didn't get to or didn't prioritize because of the time constraint:
+
+### Searching Specialties
 I wanted to update the database query to search over the specialties column, but I was having trouble getting `arrayContains` to work correctly. Rather than wasting a bunch of time to get that solved, I left it out.
 
 An alternative solution would also be to set up an API route that queried and returned all the unique specialties. Then on the page I could add a separate select dropdown for filtering specifically on that column.
+
+### Testing
+Before I began working on updating the database query I debated installing and setting up vitest or jest on the project. My preferred local development setup, projecting depending, is to have a terminal running `npm run dev` and another with `npm run test`, or often just the tests running watching for changes. Proving out my code's logic and behavior with tests can make everything smoother and reduce a lot of headaches.
+
+Though it comes at the cost of some initial setup time. In this situation where the libraries/frameworks are familiar to ones I use or have used before but different (react -> vue, nextjs -> nuxtjs, drizzle -> sequelize)  I decided not set up any testing. In a scenario where I knew I would be spending more than a few hours on this repo, I would want to have some testing in place.

--- a/DISCUSSION.md
+++ b/DISCUSSION.md
@@ -1,0 +1,5 @@
+## TODO
+
+I wanted to update the database query to search over the specialties column, but I was having trouble getting `arrayContains` to work correctly. Rather than wasting a bunch of time to get that solved, I left it out.
+
+An alternative solution would also be to set up an API route that queried and returned all the unique specialties. Then on the page I could add a separate select dropdown for filtering specifically on that column.

--- a/src/app/api/advocates/route.ts
+++ b/src/app/api/advocates/route.ts
@@ -1,12 +1,19 @@
+import { type NextRequest } from "next/server";
 import db from "../../../db";
-import { advocates } from "../../../db/schema";
-import { advocateData } from "../../../db/seed/advocates";
 
-export async function GET() {
-  // Uncomment this line to use a database
-  // const data = await db.select().from(advocates);
+const DEFAULT_LIMIT = 5;
 
-  const data = advocateData;
+export async function GET(req: NextRequest) {
+  const searchParams = req.nextUrl.searchParams
+  const offsetParam = searchParams.get('offset');
+  const limitParam = searchParams.get('limit');
+  const offset = offsetParam ? parseInt(offsetParam, 10) : 0;
+  const limit = limitParam ? parseInt(limitParam, 10) : DEFAULT_LIMIT;
+
+  const data = await db.query.advocates.findMany({
+    limit,
+    offset
+  });
 
   return Response.json({ data });
 }

--- a/src/app/api/advocates/route.ts
+++ b/src/app/api/advocates/route.ts
@@ -1,5 +1,7 @@
 import { type NextRequest } from "next/server";
 import db from "../../../db";
+import { arrayContains, ilike, or, sql } from "drizzle-orm";
+import { advocates } from "@/db/schema";
 
 const DEFAULT_LIMIT = 5;
 
@@ -7,12 +9,21 @@ export async function GET(req: NextRequest) {
   const searchParams = req.nextUrl.searchParams
   const offsetParam = searchParams.get('offset');
   const limitParam = searchParams.get('limit');
+  const queryString = searchParams.get('queryString');
   const offset = offsetParam ? parseInt(offsetParam, 10) : 0;
   const limit = limitParam ? parseInt(limitParam, 10) : DEFAULT_LIMIT;
 
   const data = await db.query.advocates.findMany({
     limit,
-    offset
+    offset,
+    ...(queryString ? {
+      where: or(
+        ilike(advocates.firstName, `%${queryString}%`),
+        ilike(advocates.lastName, `%${queryString}%`),
+        ilike(advocates.city,`%${queryString}%`),
+        ilike(advocates.degree,`%${queryString}%`)
+      )
+    } : {})
   });
 
   return Response.json({ data });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,15 +5,36 @@ import { useEffect, useState } from "react";
 export default function Home() {
   const [advocates, setAdvocates] = useState([]);
   const [filteredAdvocates, setFilteredAdvocates] = useState([]);
+  const [offset, setOffset] = useState<number>(0);
+  const [hasMore, setHasMore] = useState<boolean>(true);
+
+  const limit = 5;
+
+  const fetchAdvocates = async (queryOffset: number) => {
+    try {
+      const response = await fetch(`/api/advocates?offset=${queryOffset}&limit=${limit}`);
+      
+      const jsonData = await response.json();
+
+      if (jsonData.data.length === 0) {
+        setHasMore(false);
+      } else {
+        if (queryOffset === 0) {
+          setAdvocates(jsonData.data);
+          setFilteredAdvocates(jsonData.data);
+        } else {
+          setAdvocates(prevAdvocates => [...prevAdvocates, ...jsonData.data]);
+          setFilteredAdvocates(prevAdvocates => [...prevAdvocates, ...jsonData.data]);
+        }
+      }
+    } catch (error) {
+      console.log(error)
+    }
+  }
 
   useEffect(() => {
     console.log("fetching advocates...");
-    fetch("/api/advocates").then((response) => {
-      response.json().then((jsonResponse) => {
-        setAdvocates(jsonResponse.data);
-        setFilteredAdvocates(jsonResponse.data);
-      });
-    });
+    fetchAdvocates(offset);
   }, []);
 
   const onChange = (e) => {
@@ -40,6 +61,12 @@ export default function Home() {
     console.log(advocates);
     setFilteredAdvocates(advocates);
   };
+
+  const loadMore = () => {
+    const nextOffset = offset + limit
+    setOffset(nextOffset);
+    fetchAdvocates(nextOffset);
+  }
 
   return (
     <main style={{ margin: "24px" }}>
@@ -86,6 +113,7 @@ export default function Home() {
           })}
         </tbody>
       </table>
+      { hasMore && (<button onClick={loadMore}>Load More</button>)}
     </main>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,24 +1,37 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { ChangeEvent, useEffect, useState } from "react";
 
 export default function Home() {
   const [advocates, setAdvocates] = useState([]);
-  const [filteredAdvocates, setFilteredAdvocates] = useState([]);
   const [offset, setOffset] = useState<number>(0);
   const [hasMore, setHasMore] = useState<boolean>(true);
+  const [searchTerm, setSearchTerm] = useState<string>('');
 
   const limit = 5;
 
-  const fetchAdvocates = async (queryOffset: number) => {
+  const fetchAdvocates = async (queryOffset: number, search?: string) => {
     try {
-      const response = await fetch(`/api/advocates?offset=${queryOffset}&limit=${limit}`);
+      let url = `/api/advocates?offset=${queryOffset}&limit=${limit}`;
+
+      if (search) {
+        const queryString = encodeURIComponent(search);
+        url += `&queryString=${queryString}`;
+      }
+
+      const response = await fetch(url);
       
       const jsonData = await response.json();
 
       if (jsonData.data.length === 0) {
         setHasMore(false);
       } else {
+        if (jsonData.data.length < limit) {
+          setHasMore(false);
+        } else {
+          setHasMore(true);
+        }
+
         if (queryOffset === 0) {
           setAdvocates(jsonData.data);
           setFilteredAdvocates(jsonData.data);
@@ -32,34 +45,30 @@ export default function Home() {
     }
   }
 
+  const reset = () => {
+    setOffset(0);
+    fetchAdvocates(0);
+  }
+
   useEffect(() => {
     console.log("fetching advocates...");
     fetchAdvocates(offset);
   }, []);
 
-  const onChange = (e) => {
+  const onChange = (e: ChangeEvent<HTMLInputElement>) => {
     const searchTerm = e.target.value;
 
-    document.getElementById("search-term").innerHTML = searchTerm;
+    setSearchTerm(searchTerm);
 
-    console.log("filtering advocates...");
-    const filteredAdvocates = advocates.filter((advocate) => {
-      return (
-        advocate.firstName.includes(searchTerm) ||
-        advocate.lastName.includes(searchTerm) ||
-        advocate.city.includes(searchTerm) ||
-        advocate.degree.includes(searchTerm) ||
-        advocate.specialties.includes(searchTerm) ||
-        advocate.yearsOfExperience.includes(searchTerm)
-      );
-    });
-
-    setFilteredAdvocates(filteredAdvocates);
+    if (searchTerm.length > 0) {
+      fetchAdvocates(offset, searchTerm);
+    } else {
+      reset();
+    }
   };
 
   const onClick = () => {
-    console.log(advocates);
-    setFilteredAdvocates(advocates);
+    reset();
   };
 
   const loadMore = () => {
@@ -76,7 +85,7 @@ export default function Home() {
       <div>
         <p>Search</p>
         <p>
-          Searching for: <span id="search-term"></span>
+          Searching for: <span id="search-term">{searchTerm}</span>
         </p>
         <input style={{ border: "1px solid black" }} onChange={onChange} />
         <button onClick={onClick}>Reset Search</button>
@@ -94,7 +103,7 @@ export default function Home() {
           <th>Phone Number</th>
         </thead>
         <tbody>
-          {filteredAdvocates.map((advocate) => {
+          {advocates.map((advocate) => {
             return (
               <tr>
                 <td>{advocate.firstName}</td>

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,19 +1,17 @@
-import { drizzle } from "drizzle-orm/postgres-js";
+import { drizzle, PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
+import * as schema from './schema';
 
-const setup = () => {
+type DB = PostgresJsDatabase<typeof schema>;
+
+const setup = (): DB => {
   if (!process.env.DATABASE_URL) {
-    console.error("DATABASE_URL is not set");
-    return {
-      select: () => ({
-        from: () => [],
-      }),
-    };
+    throw new Error("DATABASE_URL is not set");
   }
 
   // for query purposes
   const queryClient = postgres(process.env.DATABASE_URL);
-  const db = drizzle(queryClient);
+  const db = drizzle(queryClient, { schema });
   return db;
 };
 


### PR DESCRIPTION
## Why
The api route for getting advocates is currently doing a query with no defined where clause. This works fine for the assignment, but would not in a real world scenario with potentially thousands or tens of thousands of records in the table.

The search filtering is also operating on the results of the database query. Again this works when we have a low total number of records, can fetch everything, and load it all into the frontend. In the situation where there were too many records, and the user has to paginate or load more records, this search feature would be unintuitive behavior. The user most likely would assume the search input will search over everything not only whichever records have already been loaded on to the page.

## What
First the backend is updated to accept some query parameters for `limit` and `offset`. This allows the frontend to fetch more data as the user requests it. _(I set a default limit of 5 to make this feature visible, but in a real world situation we'd want this to be higher)_

Second there is one more optional query parameter for `queryString`. If this is included in the request then the database query will be updated to apply the filter to the text columns.